### PR TITLE
Remove apply-refact from Haskell Tools

### DIFF
--- a/tools/haskell.nix
+++ b/tools/haskell.nix
@@ -18,7 +18,6 @@ let
   ## };
   overrideHaskellForDevTools =
     new: old: {
-      apply-refact = old.apply-refact_0_10_0_0;
       Cabal = old.Cabal_3_6_3_0;
       fourmolu = old.fourmolu_0_8_2_0;
       ghc-lib-parser = old.ghc-lib-parser_9_2_4_20220729;


### PR DESCRIPTION
The reason that we added apply-refact was to be able to compile with
GHC 9.2.4. However, we do not use GHC 9.2.4 always.

Therefore, I am removing it from here in favour of giving the control
to call-site.
